### PR TITLE
Update standings page for UTR-style scoring

### DIFF
--- a/standings.html
+++ b/standings.html
@@ -184,8 +184,8 @@
           <option value="">Select Team 1</option>
         </select>
         <div class="inline">
-          <label>Sets Won</label>
-          <input type="number" id="team1Sets" placeholder="0–5" min="0" max="5" class="number-input" required />
+          <label>Games Won</label>
+          <input type="number" id="team1Games" placeholder="0–30" min="0" max="30" step="1" class="number-input" required />
         </div>
       </div>
 
@@ -197,13 +197,13 @@
           <option value="">Select Team 2</option>
         </select>
         <div class="inline">
-          <label>Sets Won</label>
-          <input type="number" id="team2Sets" placeholder="0–5" min="0" max="5" class="number-input" required />
+          <label>Games Won</label>
+          <input type="number" id="team2Games" placeholder="0–30" min="0" max="30" step="1" class="number-input" required />
         </div>
       </div>
     </div>
 
-    <p class="legend">Winner (≥3 sets) gets <strong>2 points</strong>. Loser gets <strong>0</strong>. Total sets must be between <strong>3</strong> and <strong>5</strong>.</p>
+    <p class="legend">Universal Tennis format: enter total <strong>games won</strong> by each team (include the tiebreak game if played). Winner earns <strong>1 match point</strong>.</p>
 
     <div class="form-actions">
       <button class="btn success" id="addBtn">Save Result</button>
@@ -222,16 +222,20 @@
           <th>Rank</th>
           <th>Team</th>
           <th>Matches</th>
-          <th>Points</th>
-          <th>Sets Won</th>
+          <th>Match Wins</th>
+          <th>Match Losses</th>
+          <th>Games Won</th>
+          <th>Games Lost</th>
+          <th>Game Diff</th>
+          <th>Match Points</th>
         </tr>
         </thead>
         <tbody id="standingsBody">
-        <tr><td colspan="5" class="center-cell" style="color:var(--muted);">No results yet. Add a match to see standings.</td></tr>
+        <tr><td colspan="9" class="center-cell" style="color:var(--muted);">No results yet. Add a match to see standings.</td></tr>
         </tbody>
       </table>
     </div>
-    <p class="hint">Sorted by Points → Sets (playoff top-4 highlighted).</p>
+    <p class="hint">Sorted by Match Points → Game Differential → Games Won (top 4 highlighted).</p>
   </section>
 
   <!-- Match History -->
@@ -243,7 +247,7 @@
         <tr>
           <th>#</th>
           <th>Teams</th>
-          <th>Sets</th>
+          <th>Games</th>
           <th>Winner</th>
           <th>Date/Time</th>
         </tr>
@@ -273,13 +277,31 @@
     "Court Conquerors"
   ];
 
+  function upgradeMatch(m){
+    if(!m || !m.t1 || !m.t2) return null;
+    const g1Raw = typeof m.g1 !== 'undefined' ? Number(m.g1) : Number(m.s1 ?? 0);
+    const g2Raw = typeof m.g2 !== 'undefined' ? Number(m.g2) : Number(m.s2 ?? 0);
+    if(!Number.isFinite(g1Raw) || !Number.isFinite(g2Raw)) return null;
+    const g1 = Math.round(g1Raw);
+    const g2 = Math.round(g2Raw);
+    if(g1 < 0 || g2 < 0 || g1 > 40 || g2 > 40) return null;
+    const derivedWin = g1 === g2 ? null : (g1 > g2 ? m.t1 : m.t2);
+    const win = (m.win === m.t1 || m.win === m.t2) ? m.win : derivedWin;
+    const tsNumber = Number(m.ts);
+    const ts = Number.isFinite(tsNumber) ? tsNumber : Date.now();
+    return { t1:m.t1, t2:m.t2, g1, g2, win, ts };
+  }
+
   function loadMatches(){
-    try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) || []; }
+    try {
+      const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      return raw.map(upgradeMatch).filter(Boolean);
+    }
     catch { return []; }
   }
   function saveMatches(list){ localStorage.setItem(STORAGE_KEY, JSON.stringify(list)); }
 
-  let matches = loadMatches(); // [{t1,t2,s1,s2,ts,win}]
+  let matches = loadMatches(); // [{t1,t2,g1,g2,ts,win}]
 
   /* ==========
      UI: Nav (mobile)
@@ -323,16 +345,14 @@
   fillTeams();
 
   /* ==========
-     Validation helpers (Best-of-5)
+     Validation helpers (UTR games-based)
      ========== */
-  function validateSets(a,b){
-    const s1 = Number(a), s2 = Number(b);
-    if(Number.isNaN(s1)||Number.isNaN(s2)) return { ok:false, msg:'Enter numeric sets for both teams.' };
-    if(s1<0||s2<0||s1>5||s2>5) return { ok:false, msg:'Sets must be between 0 and 5.' };
-    const total = s1+s2;
-    if(total<3 || total>5) return { ok:false, msg:'Total sets must be between 3 and 5.' };
-    if(s1===s2) return { ok:false, msg:'No ties allowed in best-of-5. One team must have more sets.' };
-    if(s1<3 && s2<3) return { ok:false, msg:'Winner must have at least 3 sets.' };
+  function validateGames(a,b){
+    const g1 = Number(a), g2 = Number(b);
+    if(!Number.isInteger(g1) || !Number.isInteger(g2)) return { ok:false, msg:'Enter whole-number games for both teams.' };
+    if(g1<0 || g2<0) return { ok:false, msg:'Games cannot be negative.' };
+    if(g1>40 || g2>40) return { ok:false, msg:'Games look unusually high. Please double check.' };
+    if(g1 === g2) return { ok:false, msg:'Include the tiebreak game so one team has more games.' };
     return { ok:true };
   }
 
@@ -341,19 +361,38 @@
      ========== */
   function computeStandings(){
     const stats = {};
-    TEAMS.forEach(n => stats[n] = { team:n, matches:0, points:0, sets:0 });
+    TEAMS.forEach(n => stats[n] = {
+      team:n,
+      matches:0,
+      wins:0,
+      losses:0,
+      gamesFor:0,
+      gamesAgainst:0,
+      points:0
+    });
     for(const m of matches){
       // increment matches
       stats[m.t1].matches++; stats[m.t2].matches++;
-      // sets
-      stats[m.t1].sets += m.s1; stats[m.t2].sets += m.s2;
-      // points (2 for winner)
-      if(m.win === m.t1) stats[m.t1].points += 2;
-      else stats[m.t2].points += 2;
+      // games
+      stats[m.t1].gamesFor += m.g1; stats[m.t1].gamesAgainst += m.g2;
+      stats[m.t2].gamesFor += m.g2; stats[m.t2].gamesAgainst += m.g1;
+      if(m.win === m.t1){
+        stats[m.t1].wins++; stats[m.t2].losses++;
+        stats[m.t1].points++;
+      } else if(m.win === m.t2){
+        stats[m.t2].wins++; stats[m.t1].losses++;
+        stats[m.t2].points++;
+      }
     }
-    // sort: Points desc → Sets desc → Name asc
+    Object.values(stats).forEach(s => s.gameDiff = s.gamesFor - s.gamesAgainst);
+    // sort: Match points → Game differential → Games for → Name
     const arr = Object.values(stats)
-      .sort((a,b)=> (b.points-a.points) || (b.sets-a.sets) || a.team.localeCompare(b.team));
+      .sort((a,b)=>
+        (b.points - a.points) ||
+        (b.gameDiff - a.gameDiff) ||
+        (b.gamesFor - a.gamesFor) ||
+        a.team.localeCompare(b.team)
+      );
     return arr;
   }
 
@@ -362,7 +401,7 @@
     const rows = computeStandings();
 
     if(matches.length === 0){
-      tbody.innerHTML = '<tr><td colspan="5" class="center-cell" style="color:var(--muted);">No results yet. Add a match to see standings.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="9" class="center-cell" style="color:var(--muted);">No results yet. Add a match to see standings.</td></tr>';
       return;
     }
 
@@ -371,8 +410,12 @@
         <td class="rank-cell">${i+1}</td>
         <td class="team-cell">${r.team}</td>
         <td class="center-cell">${r.matches}</td>
+        <td class="center-cell">${r.wins}</td>
+        <td class="center-cell">${r.losses}</td>
+        <td class="center-cell">${r.gamesFor}</td>
+        <td class="center-cell">${r.gamesAgainst}</td>
+        <td class="center-cell">${r.gameDiff}</td>
         <td class="points-cell">${r.points}</td>
-        <td class="center-cell">${r.sets}</td>
       </tr>
     `).join('');
   }
@@ -387,7 +430,7 @@
       <tr>
         <td class="rank-cell">${matches.length - idx}</td>
         <td class="team-cell">${m.t1} vs ${m.t2}</td>
-        <td class="center-cell">${m.s1}-${m.s2}</td>
+        <td class="center-cell">${m.g1}-${m.g2}</td>
         <td class="points-cell">${m.win}</td>
         <td class="center-cell">${new Date(m.ts).toLocaleString()}</td>
       </tr>
@@ -405,30 +448,30 @@
      ========== */
   document.getElementById('addBtn').addEventListener('click', () => {
     const a = t1.value.trim(), b = t2.value.trim();
-    const s1 = Number(document.getElementById('team1Sets').value);
-    const s2 = Number(document.getElementById('team2Sets').value);
+    const g1 = Number(document.getElementById('team1Games').value);
+    const g2 = Number(document.getElementById('team2Games').value);
 
     if(!a || !b) return alert('Select both teams.');
     if(a === b) return alert('A team cannot play itself.');
-    const v = validateSets(s1,s2);
+    const v = validateGames(g1,g2);
     if(!v.ok) return alert('⚠️ ' + v.msg);
 
-    const win = s1 > s2 ? a : b;
-    matches.unshift({ t1:a, t2:b, s1, s2, win, ts: Date.now() });
+    const win = g1 > g2 ? a : b;
+    matches.unshift({ t1:a, t2:b, g1, g2, win, ts: Date.now() });
 
     // Clear inputs
     t1.value = ''; t2.value = '';
-    document.getElementById('team1Sets').value = '';
-    document.getElementById('team2Sets').value = '';
+    document.getElementById('team1Games').value = '';
+    document.getElementById('team2Games').value = '';
 
     refresh();
-    alert(`✅ Saved: ${a} ${s1}-${s2} ${b}\nWinner: ${win} (2 pts)`);
+    alert(`✅ Saved: ${a} ${g1}-${g2} ${b}\nWinner: ${win} (+1 match point)`);
   });
 
   document.getElementById('undoBtn').addEventListener('click', () => {
     if(matches.length === 0) return alert('Nothing to undo.');
     const last = matches[0];
-    if(!confirm(`Undo last match?\n${last.t1} ${last.s1}-${last.s2} ${last.t2}`)) return;
+    if(!confirm(`Undo last match?\n${last.t1} ${last.g1}-${last.g2} ${last.t2}`)) return;
     matches.shift();
     refresh();
   });
@@ -458,11 +501,14 @@
         const data = JSON.parse(reader.result);
         if(!Array.isArray(data)) throw new Error('Invalid JSON shape');
         // quick sanity check
-        for(const m of data){
-          if(!m.t1 || !m.t2 || typeof m.s1!=='number' || typeof m.s2!=='number') throw new Error('Malformed match entry');
-          if(!TEAMS.includes(m.t1) || !TEAMS.includes(m.t2)) throw new Error('Unknown team in data');
-        }
-        matches = data;
+        const upgraded = data.map(entry => {
+          const u = upgradeMatch(entry);
+          if(!u) throw new Error('Malformed match entry (invalid games)');
+          if(!TEAMS.includes(u.t1) || !TEAMS.includes(u.t2)) throw new Error('Unknown team in data');
+          if(u.win !== u.t1 && u.win !== u.t2) throw new Error('Match is missing a winner');
+          return u;
+        });
+        matches = upgraded;
         refresh();
         alert('✅ Import successful.');
       } catch(err){


### PR DESCRIPTION
## Summary
- switch the standings form to capture games won and explain the UTR match-point legend
- recalculate standings using games won/lost, match wins, and new tiebreak order while migrating saved results
- tighten history rendering and import validation for the games-based data structure

## Testing
- not run (static html change)


------
https://chatgpt.com/codex/tasks/task_e_68e55a3c39f88332a7eda632956c992e