### PR TITLE
Configure Expo project for App Store deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.expo/
+dist/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# KOC Season 2 (Expo)
+
+This app is now configured for **EAS production builds** so you can deploy to the Apple App Store.
+
+## What was fixed
+
+- Added iOS/Android store version fields (`ios.buildNumber`, `android.versionCode`) in `app.json`.
+- Added iOS export-compliance flag (`ITSAppUsesNonExemptEncryption: false`) to avoid App Store submission prompts when no non-exempt encryption is used.
+- Added a production-ready `eas.json` with development/preview/production build profiles.
+- Added a deployment checklist below.
+
+## Local run
+
+```bash
+npm install
+npm run start
+```
+
+## App Store deployment steps (Expo EAS)
+
+1. Install and login to EAS CLI:
+   ```bash
+   npm install -g eas-cli
+   eas login
+   ```
+2. Configure project credentials:
+   ```bash
+   eas build:configure
+   ```
+3. Create a production iOS build:
+   ```bash
+   eas build --platform ios --profile production
+   ```
+4. Submit to App Store Connect:
+   ```bash
+   eas submit --platform ios --profile production
+   ```
+
+## Before submitting to Apple
+
+- Set your final app icon and splash image in `app.json`.
+- Verify app metadata in App Store Connect (name, screenshots, privacy policy URL, category, age rating).
+- Verify Apple Developer team access and certificates.
+- Increment versions for each release:
+  - `expo.version`
+  - `expo.ios.buildNumber`
+

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "KOC Season 2",
     "slug": "koc-season-2",
+    "scheme": "kocseason2",
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",
@@ -10,10 +11,15 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.kocseason2.app"
+      "bundleIdentifier": "com.kocseason2.app",
+      "buildNumber": "1",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.kocseason2.app",
+      "versionCode": 1,
       "adaptiveIcon": {
         "backgroundColor": "#667eea"
       }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build:ios": "eas build --platform ios --profile production",
+    "submit:ios": "eas submit --platform ios --profile production"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",


### PR DESCRIPTION
### Motivation
- Make the Expo project ready for App Store distribution by adding build metadata and EAS build profiles and to resolve deployment blockers.
- Ensure versioning and export-compliance metadata are present so App Store submission doesn't prompt for missing configuration.

### Description
- Updated `app.json` to add `scheme`, `ios.buildNumber`, `ios.infoPlist.ITSAppUsesNonExemptEncryption`, and `android.versionCode` for store readiness.
- Added an `eas.json` with `development`, `preview`, and `production` profiles (production uses `autoIncrement`).
- Added helper npm scripts in `package.json`: `build:ios` and `submit:ios` that use EAS CLI.
- Added a `README.md` documenting EAS build/submit steps and a `.gitignore` to exclude `node_modules`, `.expo`, `dist`, and log files.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('app.json','utf8')); JSON.parse(require('fs').readFileSync('eas.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"` and it succeeded.
- Ran `npx expo export --platform ios --output-dir dist` to verify the project exports an iOS bundle and it succeeded (app exported to `dist`).
- Ran `npx expo-doctor` which failed with an npm registry `403` (environment/network restriction), unrelated to the configuration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbf3337448332855dd62ef74246b0)