### PR TITLE
Add EAS production config, app metadata, .gitignore, and robust Firebase auth initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.expo/
+dist/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# KOC Season 2 (Expo)
+
+This app is now configured for **EAS production builds** so you can deploy to the Apple App Store.
+
+## What was fixed
+
+- Added iOS/Android store version fields (`ios.buildNumber`, `android.versionCode`) in `app.json`.
+- Added iOS export-compliance flag (`ITSAppUsesNonExemptEncryption: false`) to avoid App Store submission prompts when no non-exempt encryption is used.
+- Added a production-ready `eas.json` with development/preview/production build profiles.
+- Added a deployment checklist below.
+
+## Local run
+
+```bash
+npm install
+npm run start
+```
+
+## App Store deployment steps (Expo EAS)
+
+1. Install and login to EAS CLI:
+   ```bash
+   npm install -g eas-cli
+   eas login
+   ```
+2. Configure project credentials:
+   ```bash
+   eas build:configure
+   ```
+3. Create a production iOS build:
+   ```bash
+   eas build --platform ios --profile production
+   ```
+4. Submit to App Store Connect:
+   ```bash
+   eas submit --platform ios --profile production
+   ```
+
+## Before submitting to Apple
+
+- Set your final app icon and splash image in `app.json`.
+- Verify app metadata in App Store Connect (name, screenshots, privacy policy URL, category, age rating).
+- Verify Apple Developer team access and certificates.
+- Increment versions for each release:
+  - `expo.version`
+  - `expo.ios.buildNumber`
+

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "KOC Season 2",
     "slug": "koc-season-2",
+    "scheme": "kocseason2",
     "version": "1.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "light",
@@ -10,10 +11,15 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.kocseason2.app"
+      "bundleIdentifier": "com.kocseason2.app",
+      "buildNumber": "1",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.kocseason2.app",
+      "versionCode": 1,
       "adaptiveIcon": {
         "backgroundColor": "#667eea"
       }

--- a/assets/images/.gitkeep
+++ b/assets/images/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps assets/images directory for Metro asset discovery.

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build:ios": "eas build --platform ios --profile production",
+    "submit:ios": "eas submit --platform ios --profile production"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,6 @@
 import { initializeApp, getApps } from 'firebase/app';
 import { getDatabase } from 'firebase/database';
-import { getAuth } from 'firebase/auth';
+import { initializeAuth, getAuth } from 'firebase/auth/react-native';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyDbO0eP52i4t3V94bEiDcl7WoKbSrrM9VA',
@@ -14,6 +14,14 @@ const firebaseConfig = {
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
 
+let auth;
+
+try {
+  auth = initializeAuth(app);
+} catch {
+  auth = getAuth(app);
+}
+
 export const db = getDatabase(app);
-export const auth = getAuth(app);
+export { auth };
 export const MATCHES_REF = 'KOC2DBPONEW';


### PR DESCRIPTION
### Motivation
- Prepare the project for Expo EAS production builds and App Store submission by adding build metadata and deployment configuration.
- Prevent committing generated files and large folders by adding a `.gitignore`.
- Ensure Firebase auth initializes correctly in both web and React Native environments.

### Description
- Added `eas.json` with `development`, `preview`, and `production` build profiles and CLI version requirement, and added `submit.production` config.
- Updated `app.json` to include `scheme`, iOS `buildNumber`, `ITSAppUsesNonExemptEncryption: false`, and Android `versionCode` for App Store readiness.
- Added `.gitignore` to ignore `node_modules/`, `.expo/`, build outputs and common logs, and added `assets/images/.gitkeep` to preserve the assets directory for Metro.
- Updated `package.json` with `build:ios` and `submit:ios` scripts for `eas` and left `start`/platform scripts intact.
- Added a README with local run instructions and an Expo EAS App Store deployment checklist.
- Modified `src/firebase.js` to import from `firebase/auth/react-native` and attempt `initializeAuth(app)` with a fallback to `getAuth(app)` to support React Native auth initialization, and exported the resolved `auth` instance.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbf3337448332855dd62ef74246b0)